### PR TITLE
Develop

### DIFF
--- a/IntraMessaging.Tests/Context/TestMessages.cs
+++ b/IntraMessaging.Tests/Context/TestMessages.cs
@@ -3,4 +3,8 @@
     public class TestMessage : Message
     {
     }
+
+    public class UnregisteredMessage : Message
+    {
+    }
 }

--- a/IntraMessaging.Tests/IntraMessengerTests.cs
+++ b/IntraMessaging.Tests/IntraMessengerTests.cs
@@ -51,7 +51,7 @@ namespace IntraMessaging.Tests
             messenger.Send<TestMessage>(null);
             Assert.True(callback);
 
-            messenger.Reset();
+            messenger.Reset(Mode.HeavyMessaging);
             callback = false;
             messenger.Subscribe((_) => callback = true, new Type[] { typeof(TestMessage) });
 
@@ -60,6 +60,12 @@ namespace IntraMessaging.Tests
 
             messenger.Send<TestMessage>(null);
             Assert.True(callback);
+        }
+
+        [Fact]
+        public void TestSendHeavySubscribe()
+        {
+
         }
     }
 }

--- a/IntraMessaging.Tests/IntraMessengerTests.cs
+++ b/IntraMessaging.Tests/IntraMessengerTests.cs
@@ -78,6 +78,8 @@ namespace IntraMessaging.Tests
 
         #endregion
 
+        #region Subscribe Tests
+
         [Fact]
         public void TestSubscribe()
         {
@@ -126,6 +128,29 @@ namespace IntraMessaging.Tests
             messenger.Unsubscribe(unsubKey);
             Assert.Empty(messenger.Subscriptions[typeof(TestMessage)]);
             Assert.Throws<ArgumentException>(() => messenger.Unsubscribe(unsubKey));
+
+            Assert.False(callback);
+        }
+
+        #endregion
+
+        [Fact]
+        public void TestReset()
+        {
+            bool callback = false;
+            IntraMessenger messenger = new IntraMessenger();
+            messenger.ChangeMode(Mode.HeavyMessaging);
+            messenger.Subscribe((_) => callback = true);
+
+            messenger.Reset(Mode.HeavyMessaging);
+            Assert.Empty(messenger.Subscribers);
+            Assert.Equal(Mode.HeavyMessaging, messenger.OperationMode);
+
+            messenger.ChangeMode(Mode.HeavySubscribe);
+            messenger.Subscribe((_) => callback = true, new Type[] { typeof(TestMessage) });
+            messenger.Reset();
+            Assert.True(messenger.Subscriptions.Count == 1);
+            Assert.Empty(messenger.Subscriptions[IntraMessenger.SEND_TO_ALL_TYPE]);
 
             Assert.False(callback);
         }

--- a/IntraMessaging.Tests/IntraMessengerTests.cs
+++ b/IntraMessaging.Tests/IntraMessengerTests.cs
@@ -1,10 +1,13 @@
-﻿using System;
+﻿using IntraMessaging.Tests.Context;
+using System;
 using Xunit;
 
 namespace IntraMessaging.Tests
 {
     public class IntraMessengerTests
     {
+        #region Property Tests
+
         [Fact]
         public void TestPropInstance()
         {
@@ -14,25 +17,49 @@ namespace IntraMessaging.Tests
         [Fact]
         public void TestPropSubscriptions()
         {
-            IntraMessenger i = new IntraMessenger();
+            IntraMessenger messenger = new IntraMessenger();
 
-            i.ChangeMode(Mode.HeavySubscribe);
-            Assert.True(i.Subscriptions.IsReadOnly);
+            messenger.ChangeMode(Mode.HeavySubscribe);
+            Assert.True(messenger.Subscriptions.IsReadOnly);
 
-            i.ChangeMode(Mode.HeavyMessaging);
-            Assert.Throws<InvalidOperationException>(() => i.Subscriptions);
+            messenger.ChangeMode(Mode.HeavyMessaging);
+            Assert.Throws<InvalidOperationException>(() => messenger.Subscriptions);
         }
 
         [Fact]
         public void TestPropSubscribers()
         {
-            IntraMessenger i = new IntraMessenger();
+            IntraMessenger messenger = new IntraMessenger();
 
-            i.ChangeMode(Mode.HeavyMessaging);
-            Assert.True(i.Subscribers.IsReadOnly);
+            messenger.ChangeMode(Mode.HeavyMessaging);
+            Assert.True(messenger.Subscribers.IsReadOnly);
 
-            i.ChangeMode(Mode.HeavySubscribe);
-            Assert.Throws<InvalidOperationException>(() => i.Subscribers);
+            messenger.ChangeMode(Mode.HeavySubscribe);
+            Assert.Throws<InvalidOperationException>(() => messenger.Subscribers);
+        }
+
+        #endregion
+
+        [Fact]
+        public void TestSendHeavyMessaging()
+        {
+            bool callback = false;
+            IntraMessenger messenger = new IntraMessenger();
+            messenger.ChangeMode(Mode.HeavyMessaging);
+            messenger.Subscribe((_) => callback = true);
+
+            messenger.Send<TestMessage>(null);
+            Assert.True(callback);
+
+            messenger.Reset();
+            callback = false;
+            messenger.Subscribe((_) => callback = true, new Type[] { typeof(TestMessage) });
+
+            messenger.Send<UnregisteredMessage>(null);
+            Assert.False(callback);
+
+            messenger.Send<TestMessage>(null);
+            Assert.True(callback);
         }
     }
 }

--- a/IntraMessaging.Tests/IntraMessengerTests.cs
+++ b/IntraMessaging.Tests/IntraMessengerTests.cs
@@ -135,6 +135,32 @@ namespace IntraMessaging.Tests
         #endregion
 
         [Fact]
+        public void TestChangeMode()
+        {
+            bool callback = false;
+            IntraMessenger messenger = new IntraMessenger();
+            messenger.ChangeMode(Mode.HeavyMessaging);
+            Assert.Equal(Mode.HeavyMessaging, messenger.OperationMode);
+            messenger.Subscribe((_) => callback = true, new Type[] { typeof(TestMessage)});
+
+            messenger.ChangeMode(Mode.HeavySubscribe);
+            Assert.True(messenger.Subscriptions.ContainsKey(typeof(TestMessage)));
+            Assert.NotEmpty(messenger.Subscriptions[typeof(TestMessage)]);
+            Assert.True(messenger.Subscriptions.Count == 2);
+
+            messenger.ChangeMode(Mode.HeavyMessaging);
+            Assert.True(messenger.Subscribers.Count == 1);
+
+            messenger.Reset(Mode.HeavyMessaging);
+            messenger.Subscribe((_) => callback = false);
+            messenger.ChangeMode(Mode.HeavySubscribe);
+            Assert.True(messenger.Subscriptions.Count == 1);
+            Assert.NotEmpty(messenger.Subscriptions[IntraMessenger.SEND_TO_ALL_TYPE]);
+
+            Assert.False(callback);
+        }
+
+        [Fact]
         public void TestReset()
         {
             bool callback = false;

--- a/IntraMessaging.Tests/IntraMessengerTests.cs
+++ b/IntraMessaging.Tests/IntraMessengerTests.cs
@@ -51,7 +51,29 @@ namespace IntraMessaging.Tests
             messenger.Send<TestMessage>(null);
             Assert.True(callback);
 
-            messenger.Reset(Mode.HeavyMessaging);
+            //messenger.Reset(Mode.HeavyMessaging);
+            //callback = false;
+            //messenger.Subscribe((_) => callback = true, new Type[] { typeof(TestMessage) });
+
+            //messenger.Send<UnregisteredMessage>(null);
+            //Assert.False(callback);
+
+            //messenger.Send<TestMessage>(null);
+            //Assert.True(callback);
+        }
+
+        [Fact]
+        public void TestSendHeavySubscribe()
+        {
+            bool callback = false;
+            IntraMessenger messenger = new IntraMessenger();
+            messenger.ChangeMode(Mode.HeavySubscribe);
+            messenger.Subscribe((_) => callback = true);
+
+            messenger.Send<TestMessage>(null);
+            Assert.True(callback);
+
+            messenger.Reset(Mode.HeavySubscribe);
             callback = false;
             messenger.Subscribe((_) => callback = true, new Type[] { typeof(TestMessage) });
 
@@ -60,12 +82,6 @@ namespace IntraMessaging.Tests
 
             messenger.Send<TestMessage>(null);
             Assert.True(callback);
-        }
-
-        [Fact]
-        public void TestSendHeavySubscribe()
-        {
-
         }
     }
 }

--- a/IntraMessaging.Tests/IntraMessengerTests.cs
+++ b/IntraMessaging.Tests/IntraMessengerTests.cs
@@ -1,0 +1,19 @@
+﻿using Xunit;
+
+namespace IntraMessaging.Tests
+{
+    public class IntraMessengerTests
+    {
+        [Fact]
+        public void TestPropInstance()
+        {
+            Assert.NotNull(IntraMessenger.Instance);
+        }
+
+        [Fact]
+        public void TestPropSubscriptions()
+        {
+
+        }
+    }
+}

--- a/IntraMessaging.Tests/IntraMessengerTests.cs
+++ b/IntraMessaging.Tests/IntraMessengerTests.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using System;
+using Xunit;
 
 namespace IntraMessaging.Tests
 {
@@ -13,7 +14,25 @@ namespace IntraMessaging.Tests
         [Fact]
         public void TestPropSubscriptions()
         {
+            IntraMessenger i = new IntraMessenger();
 
+            i.ChangeMode(Mode.HeavySubscribe);
+            Assert.True(i.Subscriptions.IsReadOnly);
+
+            i.ChangeMode(Mode.HeavyMessaging);
+            Assert.Throws<InvalidOperationException>(() => i.Subscriptions);
+        }
+
+        [Fact]
+        public void TestPropSubscribers()
+        {
+            IntraMessenger i = new IntraMessenger();
+
+            i.ChangeMode(Mode.HeavyMessaging);
+            Assert.True(i.Subscribers.IsReadOnly);
+
+            i.ChangeMode(Mode.HeavySubscribe);
+            Assert.Throws<InvalidOperationException>(() => i.Subscribers);
         }
     }
 }

--- a/IntraMessaging.Tests/SubscriberTests.cs
+++ b/IntraMessaging.Tests/SubscriberTests.cs
@@ -54,6 +54,17 @@ namespace IntraMessaging.Tests
         }
 
         [Fact]
+        public void TestInitiateCallbackWithNoTypeChecking()
+        {
+            bool callback = false;
+            Type[] subTypes = new Type[] { typeof(TestMessage) };
+            Subscriber subscriber = new Subscriber((_) => callback = true, Guid.Empty, subTypes);
+
+            subscriber.InitiateCallback<IMessage>(null, true);
+            Assert.True(callback);
+        }
+
+        [Fact]
         public void TestEquals()
         {
             Subscriber s = GetSubscriber();

--- a/IntraMessaging/IIntraMessager.cs
+++ b/IntraMessaging/IIntraMessager.cs
@@ -9,7 +9,7 @@ namespace IntraMessaging
         IDictionary<Type, ICollection<Subscriber>> Subscriptions { get; }
         Mode OperationMode { get; }
 
-        void Send<T>(T message) where T : IMessage;
+        void Send<T>(T message) where T : IMessage, new();
         Guid Subscribe(Action<IMessage> callback, Type[] requestedMessageTypes = null);
         void Unsubscribe(Guid unsubKey);
         void ChangeMode(Mode changeTo);

--- a/IntraMessaging/IIntraMessager.cs
+++ b/IntraMessaging/IIntraMessager.cs
@@ -8,9 +8,10 @@ namespace IntraMessaging
         ICollection<Subscriber> Subscribers { get; }
         Mode OperationMode { get; }
 
-        void Enqueue<T>(T message) where T : IMessage;
+        void Send<T>(T message) where T : IMessage;
         Guid Subscribe(Action<IMessage> callback, Type[] requestedMessageTypes = null);
         void Unsubscribe(Guid unsubKey);
         void ChangeMode(Mode changeTo);
+        void Reset();
     }
 }

--- a/IntraMessaging/IIntraMessager.cs
+++ b/IntraMessaging/IIntraMessager.cs
@@ -3,12 +3,14 @@ using System.Collections.Generic;
 
 namespace IntraMessaging
 {
-    public interface IIntraMessager
+    public interface IIntraMessenger
     {
         ICollection<Subscriber> Subscribers { get; }
+        Mode OperationMode { get; }
 
         void Enqueue<T>(T message) where T : IMessage;
         Guid Subscribe(Action<IMessage> callback, Type[] requestedMessageTypes = null);
         void Unsubscribe(Guid unsubKey);
+        void ChangeMode(Mode changeTo);
     }
 }

--- a/IntraMessaging/IIntraMessager.cs
+++ b/IntraMessaging/IIntraMessager.cs
@@ -6,6 +6,7 @@ namespace IntraMessaging
     public interface IIntraMessenger
     {
         ICollection<Subscriber> Subscribers { get; }
+        IDictionary<Type, ICollection<Subscriber>> Subscriptions { get; }
         Mode OperationMode { get; }
 
         void Send<T>(T message) where T : IMessage;

--- a/IntraMessaging/IIntraMessager.cs
+++ b/IntraMessaging/IIntraMessager.cs
@@ -13,6 +13,6 @@ namespace IntraMessaging
         Guid Subscribe(Action<IMessage> callback, Type[] requestedMessageTypes = null);
         void Unsubscribe(Guid unsubKey);
         void ChangeMode(Mode changeTo);
-        void Reset();
+        void Reset(Mode mode);
     }
 }

--- a/IntraMessaging/IntraMessager.cs
+++ b/IntraMessaging/IntraMessager.cs
@@ -80,12 +80,25 @@ namespace IntraMessaging
             return unsubKey;
         }
 
-        public void Unsubscribe(Guid unsubKey)
+        public void Unsubscribe(Guid unsubscribeKey)
         {
-            if (_subscribers.ContainsKey(unsubKey))
-                _subscribers.Remove(unsubKey);
-            else
-                throw new ArgumentException("A subscriber with the specified unsubscription key does not exist");
+            switch (OperationMode)
+            {
+                case Mode.HeavyMessaging:
+                    if (_subscribers.ContainsKey(unsubscribeKey))
+                        _subscribers.Remove(unsubscribeKey);
+                    else
+                        throw new ArgumentException("A subscriber with the specified unsubscription key does not exist");
+                    break;
+                case Mode.HeavySubscribe:
+                    foreach (List<Subscriber> element in _subscriptions.Values)
+                    {
+                        int index = element.FindIndex(s => s.UnsubscribeKey == unsubscribeKey);
+                        if (index != -1)
+                            element.RemoveAt(index);
+                    }
+                    break;
+            }
         }
 
         /// <summary>

--- a/IntraMessaging/IntraMessager.cs
+++ b/IntraMessaging/IntraMessager.cs
@@ -110,6 +110,19 @@ namespace IntraMessaging
                         }
                     }
                     break;
+                case Mode.HeavySubscribe:
+                    _subscriptions.Clear();
+                    foreach (Subscriber element in _subscribers.Values)
+                    {
+                        foreach (Type type in element.MessageTypes)
+                        {
+                            if (!_subscriptions.ContainsKey(type))
+                                _subscriptions.Add(type, new List<Subscriber>());
+
+                            _subscriptions[type].Add(element);
+                        }
+                    }
+                    break;
             }
         }
     }

--- a/IntraMessaging/IntraMessager.cs
+++ b/IntraMessaging/IntraMessager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
@@ -18,7 +19,7 @@ namespace IntraMessaging
 
         #region Properties
 
-        public static IIntraMessenger Instance { get; } = new IntraMessenger();
+        public static IntraMessenger Instance { get; } = new IntraMessenger();
 
         /// <summary>
         /// Gets a read only collection of the subscriptions by type to this messenger when using <see cref="Mode.HeavySubscribe"/>
@@ -30,9 +31,8 @@ namespace IntraMessaging
                 if (OperationMode != Mode.HeavySubscribe)
                     throw new InvalidOperationException("Can only retrieve this collection in " + nameof(Mode.HeavySubscribe) + " mode");
 
-                return _subscriptions
-                    .Cast<dynamic>()
-                    .ToDictionary(k => (Type)k.Key, v => (ICollection<Subscriber>)v.Value.AsReadOnly());
+                var converted = _subscriptions.ToDictionary(k => k.Key, v => (ICollection<Subscriber>)v.Value.AsReadOnly());
+                return new ReadOnlyDictionary<Type, ICollection<Subscriber>>(converted);
             }
         }
 
@@ -61,7 +61,10 @@ namespace IntraMessaging
 
         static IntraMessenger() { }
 
-        private IntraMessenger()
+        /// <summary>
+        /// This ctor used internally to setup instance and for testing
+        /// </summary>
+        internal IntraMessenger()
         {
             _subscribers = new Dictionary<Guid, Subscriber>();
             _subscriptions = new Dictionary<Type, List<Subscriber>>();

--- a/IntraMessaging/IntraMessager.cs
+++ b/IntraMessaging/IntraMessager.cs
@@ -8,12 +8,12 @@ using System.Threading.Tasks;
 
 namespace IntraMessaging
 {
-    public sealed class IntraMessager : IIntraMessager
+    public sealed class IntraMessenger : IIntraMessenger
     {
         private readonly Dictionary<Guid, Subscriber> _subscribers;
         private readonly Dictionary<Type, List<Subscriber>> _subscriptions;
 
-        public static IIntraMessager Instance { get; } = new IntraMessager();
+        public static IIntraMessenger Instance { get; } = new IntraMessenger();
 
         /// <summary>
         /// Gets a read only collection of the subscriptions by type to this messenger when using <see cref="Mode.HeavySubscribe"/>
@@ -50,9 +50,9 @@ namespace IntraMessaging
         /// </summary>
         public Mode OperationMode { get; }
 
-        static IntraMessager() { }
+        static IntraMessenger() { }
 
-        private IntraMessager()
+        private IntraMessenger()
         {
             _subscribers = new Dictionary<Guid, Subscriber>();
             _subscriptions = new Dictionary<Type, List<Subscriber>>();
@@ -86,6 +86,31 @@ namespace IntraMessaging
                 _subscribers.Remove(unsubKey);
             else
                 throw new ArgumentException("A subscriber with the specified unsubscription key does not exist");
+        }
+
+        /// <summary>
+        /// Changes the <see cref="Mode"/> of this messenger. Note that this can be an intensive operation
+        /// </summary>
+        /// <param name="changeTo">The mode to change to</param>
+        public void ChangeMode(Mode changeTo)
+        {
+            if (changeTo == OperationMode)
+                return;
+
+            switch (changeTo)
+            {
+                case Mode.HeavyMessaging:
+                    _subscribers.Clear();
+                    foreach (List<Subscriber> element in _subscriptions.Values)
+                    {
+                        foreach (Subscriber subscriber in element)
+                        {
+                            if (!_subscribers.ContainsKey(subscriber.UnsubscribeKey))
+                                _subscribers.Add(subscriber.UnsubscribeKey, subscriber);
+                        }
+                    }
+                    break;
+            }
         }
     }
 }

--- a/IntraMessaging/IntraMessager.cs
+++ b/IntraMessaging/IntraMessager.cs
@@ -76,7 +76,24 @@ namespace IntraMessaging
                 throw new ArgumentException("Callback cannot be null");
 
             Guid unsubKey = Guid.NewGuid();
-            _subscribers.Add(unsubKey, new Subscriber(callback, unsubKey, requestedMessageTypes));
+            Subscriber subscriber = new Subscriber(callback, unsubKey, requestedMessageTypes);
+
+            switch (OperationMode)
+            {
+                case Mode.HeavyMessaging:
+                    _subscribers.Add(unsubKey, subscriber);
+                    break;
+                case Mode.HeavySubscribe:
+                    foreach (Type type in requestedMessageTypes)
+                    {
+                        if (!_subscriptions.ContainsKey(type))
+                            _subscriptions.Add(type, new List<Subscriber>());
+
+                        _subscriptions[type].Add(subscriber);
+                    }
+                    break;
+            }
+
             return unsubKey;
         }
 

--- a/IntraMessaging/IntraMessager.cs
+++ b/IntraMessaging/IntraMessager.cs
@@ -215,12 +215,12 @@ namespace IntraMessaging
         /// <summary>
         /// Clears any subscriptions and changes to the default mode <see cref="Mode.HeavySubscribe"/>
         /// </summary>
-        public void Reset()
+        public void Reset(Mode mode = Mode.HeavySubscribe)
         {
             _subscribers.Clear();
             _subscriptions.Clear();
             _subscriptions.Add(SEND_TO_ALL_TYPE, new List<Subscriber>());
-            OperationMode = Mode.HeavySubscribe;
+            OperationMode = mode;
         }
     }
 }

--- a/IntraMessaging/IntraMessager.cs
+++ b/IntraMessaging/IntraMessager.cs
@@ -192,7 +192,6 @@ namespace IntraMessaging
             switch (changeTo)
             {
                 case Mode.HeavyMessaging:
-                    _subscribers.Clear();
                     foreach (List<Subscriber> element in _subscriptions.Values)
                     {
                         foreach (Subscriber subscriber in element)
@@ -201,11 +200,18 @@ namespace IntraMessaging
                                 _subscribers.Add(subscriber.UnsubscribeKey, subscriber);
                         }
                     }
+                    _subscriptions.Clear();
+                    _subscriptions.Add(SEND_TO_ALL_TYPE, new List<Subscriber>());
                     break;
                 case Mode.HeavySubscribe:
-                    _subscriptions.Clear();
                     foreach (Subscriber element in _subscribers.Values)
                     {
+                        if (element.MessageTypes == null)
+                        {
+                            _subscriptions[SEND_TO_ALL_TYPE].Add(element);
+                            continue;
+                        }
+
                         foreach (Type type in element.MessageTypes)
                         {
                             if (!_subscriptions.ContainsKey(type))
@@ -214,6 +220,7 @@ namespace IntraMessaging
                             _subscriptions[type].Add(element);
                         }
                     }
+                    _subscribers.Clear();
                     break;
             }
 

--- a/IntraMessaging/IntraMessaging.csproj
+++ b/IntraMessaging/IntraMessaging.csproj
@@ -14,14 +14,16 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <NeutralLanguage>en-NZ</NeutralLanguage>
     <RepositoryType>Git</RepositoryType>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <PackageReleaseNotes>BREAKING CHANGES:
-IntraMessenger.Subscribe no longer takes Guid key, instead opting to return a unique key each time
+- IntraMessenger.Subscribe no longer takes Guid key, instead opting to return a unique key each time
+- Renamed IntraMessager to IntraMessenger
+- Removed IntraMessenger.EnqueueAsync
+- Renamed IntraMessenger.Enqueue to Send
 
 Other Changelog:
-Add operation mode (functionality not implemented)
-Parameter guard checking on IntraMessenger.Subscribe
-Update equals and GetHashCode of subscriber to use only SubscriptionSet and UnsubKey
+- Add operation modes to suit different use cases
+- Added IntraMessenger.Reset
 </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/IntraMessaging/IntraMessaging.csproj
+++ b/IntraMessaging/IntraMessaging.csproj
@@ -14,7 +14,15 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <NeutralLanguage>en-NZ</NeutralLanguage>
     <RepositoryType>Git</RepositoryType>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
+    <PackageReleaseNotes>BREAKING CHANGES:
+IntraMessenger.Subscribe no longer takes Guid key, instead opting to return a unique key each time
+
+Other Changelog:
+Add operation mode (functionality not implemented)
+Parameter guard checking on IntraMessenger.Subscribe
+Update equals and GetHashCode of subscriber to use only SubscriptionSet and UnsubKey
+</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/IntraMessaging/IntraMessaging.csproj
+++ b/IntraMessaging/IntraMessaging.csproj
@@ -32,8 +32,4 @@ Update equals and GetHashCode of subscriber to use only SubscriptionSet and Unsu
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-  </ItemGroup>
-
 </Project>

--- a/IntraMessaging/Mode.cs
+++ b/IntraMessaging/Mode.cs
@@ -6,7 +6,7 @@
     public enum Mode
     {
         /// <summary>
-        /// Use this mode if you have a large number of subscribers and/or are sending a large number of messages
+        /// Default mode. Use this mode if you have a large number of subscribers and/or are sending a large number of messages
         /// </summary>
         HeavySubscribe = 0,
 

--- a/IntraMessaging/Subscriber.cs
+++ b/IntraMessaging/Subscriber.cs
@@ -50,9 +50,16 @@ namespace IntraMessaging
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="message">The message to send</param>
+        /// <param name="skipTypeChecking">Indicates whether to skip the comparison to <see cref="MessageTypes"/> before initiating the callback</param>
         /// <returns>A value indicating whether the callback was run</returns>
-        internal bool InitiateCallback<T>(T message) where T : IMessage
+        internal bool InitiateCallback<T>(T message, bool skipTypeChecking = false) where T : IMessage
         {
+            if (skipTypeChecking)
+            {
+                Callback.Invoke(message);
+                return true;
+            }
+
             switch (SubscriptionSet)
             {
                 case SubscriptionSet.All:


### PR DESCRIPTION
This PR brings a number of functionality and usability improvements to IntraMessenging, and bumps the version to 1.0.3. See description below as stated in nuget package release notes:

BREAKING CHANGES:
- IntraMessenger.Subscribe no longer takes Guid key, instead opting to return a unique key each time
- Renamed IntraMessager to IntraMessenger
- Removed IntraMessenger.EnqueueAsync
- Renamed IntraMessenger.Enqueue to Send

Other Changelog:
- Add operation modes to suit different use cases
- Added IntraMessenger.Reset